### PR TITLE
feat(project-chat): add task detail chat with @mentions and full backend integration

### DIFF
--- a/apps/api/prisma/migrations/20260304053000_project_chat/migration.sql
+++ b/apps/api/prisma/migrations/20260304053000_project_chat/migration.sql
@@ -1,0 +1,41 @@
+-- CreateTable
+CREATE TABLE "ProjectChatMessage" (
+    "id" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "authorId" TEXT NOT NULL,
+
+    CONSTRAINT "ProjectChatMessage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ProjectChatMention" (
+    "id" TEXT NOT NULL,
+    "messageId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "ProjectChatMention_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ProjectChatMessage_projectId_createdAt_idx" ON "ProjectChatMessage"("projectId", "createdAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ProjectChatMention_messageId_userId_key" ON "ProjectChatMention"("messageId", "userId");
+
+-- CreateIndex
+CREATE INDEX "ProjectChatMention_userId_idx" ON "ProjectChatMention"("userId");
+
+-- AddForeignKey
+ALTER TABLE "ProjectChatMessage" ADD CONSTRAINT "ProjectChatMessage_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProjectChatMessage" ADD CONSTRAINT "ProjectChatMessage_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProjectChatMention" ADD CONSTRAINT "ProjectChatMention_messageId_fkey" FOREIGN KEY ("messageId") REFERENCES "ProjectChatMessage"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProjectChatMention" ADD CONSTRAINT "ProjectChatMention_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -16,10 +16,12 @@ model User {
   providerId    String
   createdAt     DateTime  @default(now())
 
-  ownedTeams    Team[]     @relation("TeamOwner")
-  memberships   TeamMember[]
-  assignedTasks Task[]     @relation("TaskAssignee")
-  createdTasks  Task[]     @relation("TaskCreator")
+  ownedTeams      Team[]               @relation("TeamOwner")
+  memberships     TeamMember[]
+  assignedTasks   Task[]               @relation("TaskAssignee")
+  createdTasks    Task[]               @relation("TaskCreator")
+  projectMessages ProjectChatMessage[] @relation("ProjectChatAuthor")
+  chatMentions    ProjectChatMention[] @relation("ProjectChatMentionedUser")
 
   @@unique([provider, providerId])
 }
@@ -63,9 +65,10 @@ model Project {
   status      ProjectStatus @default(ACTIVE)
   createdAt   DateTime      @default(now())
 
-  teamId String
-  team   Team   @relation(fields: [teamId], references: [id], onDelete: Cascade)
-  tasks  Task[]
+  teamId       String
+  team         Team                @relation(fields: [teamId], references: [id], onDelete: Cascade)
+  tasks        Task[]
+  chatMessages ProjectChatMessage[]
 }
 
 enum ProjectStatus {
@@ -92,6 +95,36 @@ model Task {
 
   creatorId String
   creator   User    @relation("TaskCreator", fields: [creatorId], references: [id])
+}
+
+model ProjectChatMessage {
+  id        String   @id @default(cuid())
+  content   String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  projectId String
+  project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  authorId String
+  author   User    @relation("ProjectChatAuthor", fields: [authorId], references: [id], onDelete: Cascade)
+
+  mentions ProjectChatMention[]
+
+  @@index([projectId, createdAt])
+}
+
+model ProjectChatMention {
+  id String @id @default(cuid())
+
+  messageId String
+  message   ProjectChatMessage @relation(fields: [messageId], references: [id], onDelete: Cascade)
+
+  userId String
+  user   User @relation("ProjectChatMentionedUser", fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([messageId, userId])
+  @@index([userId])
 }
 
 enum TaskStatus {

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -5,6 +5,7 @@ import { AuthModule } from "./auth/auth.module";
 import { JwtAuthGuard } from "./auth/guards/jwt-auth.guard";
 import { MailModule } from "./mail/mail.module";
 import { PrismaModule } from "./prisma/prisma.module";
+import { ProjectChatModule } from "./project-chat/project-chat.module";
 import { ProjectsModule } from "./projects/projects.module";
 import { TasksModule } from "./tasks/tasks.module";
 import { TeamsModule } from "./teams/teams.module";
@@ -17,6 +18,7 @@ import { UsersModule } from "./users/users.module";
     AuthModule,
     TeamsModule,
     ProjectsModule,
+    ProjectChatModule,
     TasksModule,
     UsersModule,
   ],

--- a/apps/api/src/project-chat/dto/create-project-chat-message.dto.ts
+++ b/apps/api/src/project-chat/dto/create-project-chat-message.dto.ts
@@ -1,0 +1,14 @@
+import { ArrayMaxSize, IsArray, IsOptional, IsString, MaxLength, MinLength } from "class-validator";
+
+export class CreateProjectChatMessageDto {
+  @IsString()
+  @MinLength(1)
+  @MaxLength(2000)
+  content!: string;
+
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(20)
+  @IsString({ each: true })
+  mentionUserIds?: string[];
+}

--- a/apps/api/src/project-chat/project-chat.controller.ts
+++ b/apps/api/src/project-chat/project-chat.controller.ts
@@ -1,0 +1,29 @@
+import { Body, Controller, Get, Param, Post, UseGuards } from "@nestjs/common";
+import type { ProjectChatMessage } from "@repo/types";
+
+import { CurrentUser } from "../auth/decorators/current-user.decorator";
+import type { AuthUser } from "../auth/interfaces/auth-user.interface";
+import { ProjectMemberGuard } from "../tasks/guards/project-member.guard";
+
+import { CreateProjectChatMessageDto } from "./dto/create-project-chat-message.dto";
+import { ProjectChatService } from "./project-chat.service";
+
+@UseGuards(ProjectMemberGuard)
+@Controller("projects/:projectId/chat/messages")
+export class ProjectChatController {
+  constructor(private readonly projectChatService: ProjectChatService) {}
+
+  @Get()
+  listMessages(@Param("projectId") projectId: string): Promise<ProjectChatMessage[]> {
+    return this.projectChatService.listMessages(projectId);
+  }
+
+  @Post()
+  createMessage(
+    @Param("projectId") projectId: string,
+    @Body() dto: CreateProjectChatMessageDto,
+    @CurrentUser() user: AuthUser,
+  ): Promise<ProjectChatMessage> {
+    return this.projectChatService.createMessage(projectId, dto, user);
+  }
+}

--- a/apps/api/src/project-chat/project-chat.module.ts
+++ b/apps/api/src/project-chat/project-chat.module.ts
@@ -1,0 +1,15 @@
+import { Module } from "@nestjs/common";
+
+import { PrismaModule } from "../prisma/prisma.module";
+import { ProjectMemberGuard } from "../tasks/guards/project-member.guard";
+
+import { ProjectChatController } from "./project-chat.controller";
+import { ProjectChatService } from "./project-chat.service";
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [ProjectChatController],
+  providers: [ProjectChatService, ProjectMemberGuard],
+  exports: [ProjectChatService],
+})
+export class ProjectChatModule {}

--- a/apps/api/src/project-chat/project-chat.service.spec.ts
+++ b/apps/api/src/project-chat/project-chat.service.spec.ts
@@ -1,0 +1,123 @@
+import { NotFoundException } from "@nestjs/common";
+
+import { ProjectChatService } from "./project-chat.service";
+
+describe("ProjectChatService", () => {
+  it("creates a message and resolves mentions from content and explicit ids", async () => {
+    const create = jest.fn().mockResolvedValue({ id: "msg_1" });
+    const service = new ProjectChatService({
+      project: {
+        findUnique: jest.fn().mockResolvedValue({ teamId: "team_1" }),
+      },
+      teamMember: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            userId: "user_1",
+            user: {
+              id: "user_1",
+              email: "owner@example.com",
+              name: "Owner",
+              avatarUrl: null,
+            },
+          },
+          {
+            userId: "user_2",
+            user: {
+              id: "user_2",
+              email: "alice@example.com",
+              name: "Alice Johnson",
+              avatarUrl: null,
+            },
+          },
+        ]),
+      },
+      projectChatMessage: { create },
+    } as never);
+
+    await service.createMessage(
+      "project_1",
+      {
+        content: "Hello @alice and @alice.johnson",
+        mentionUserIds: ["user_2"],
+      },
+      {
+        sub: "user_1",
+        email: "owner@example.com",
+        provider: "github",
+      },
+    );
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          projectId: "project_1",
+          authorId: "user_1",
+          content: "Hello @alice and @alice.johnson",
+          mentions: {
+            create: [{ userId: "user_2" }],
+          },
+        }),
+      }),
+    );
+  });
+
+  it("does not create mentions for users outside project team", async () => {
+    const create = jest.fn().mockResolvedValue({ id: "msg_1" });
+    const service = new ProjectChatService({
+      project: {
+        findUnique: jest.fn().mockResolvedValue({ teamId: "team_1" }),
+      },
+      teamMember: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            userId: "user_1",
+            user: {
+              id: "user_1",
+              email: "owner@example.com",
+              name: "Owner",
+              avatarUrl: null,
+            },
+          },
+        ]),
+      },
+      projectChatMessage: { create },
+    } as never);
+
+    await service.createMessage(
+      "project_1",
+      {
+        content: "Hey @external",
+        mentionUserIds: ["user_999"],
+      },
+      {
+        sub: "user_1",
+        email: "owner@example.com",
+        provider: "github",
+      },
+    );
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          mentions: undefined,
+        }),
+      }),
+    );
+  });
+
+  it("throws when project does not exist", async () => {
+    const service = new ProjectChatService({
+      project: {
+        findUnique: jest.fn().mockResolvedValue(null),
+      },
+    } as never);
+
+    await expect(
+      service.createMessage(
+        "missing_project",
+        { content: "Message" },
+        { sub: "user_1", email: "user@example.com", provider: "github" },
+      ),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+});

--- a/apps/api/src/project-chat/project-chat.service.ts
+++ b/apps/api/src/project-chat/project-chat.service.ts
@@ -1,0 +1,197 @@
+import { Injectable, NotFoundException, ServiceUnavailableException } from "@nestjs/common";
+import { Prisma } from "@prisma/client";
+import type { ProjectChatMessage } from "@repo/types";
+
+import type { AuthUser } from "../auth/interfaces/auth-user.interface";
+import { PrismaService } from "../prisma/prisma.service";
+
+import type { CreateProjectChatMessageDto } from "./dto/create-project-chat-message.dto";
+
+type TeamMemberWithUser = {
+  userId: string;
+  user: {
+    id: string;
+    email: string;
+    name: string | null;
+    avatarUrl: string | null;
+  };
+};
+
+const USER_SUMMARY_SELECT = {
+  id: true,
+  email: true,
+  name: true,
+  avatarUrl: true,
+} as const;
+
+@Injectable()
+export class ProjectChatService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async listMessages(projectId: string): Promise<ProjectChatMessage[]> {
+    try {
+      return await this.prisma.projectChatMessage.findMany({
+        where: { projectId },
+        include: {
+          author: {
+            select: USER_SUMMARY_SELECT,
+          },
+          mentions: {
+            include: {
+              user: {
+                select: USER_SUMMARY_SELECT,
+              },
+            },
+          },
+        },
+        orderBy: {
+          createdAt: "asc",
+        },
+      });
+    } catch (error) {
+      this.rethrowPrismaRuntimeError(error);
+    }
+  }
+
+  async createMessage(
+    projectId: string,
+    dto: CreateProjectChatMessageDto,
+    currentUser: AuthUser,
+  ): Promise<ProjectChatMessage> {
+    try {
+      const project = await this.prisma.project.findUnique({
+        where: { id: projectId },
+        select: { teamId: true },
+      });
+
+      if (!project) {
+        throw new NotFoundException("Project not found");
+      }
+
+      const teamMembers = await this.prisma.teamMember.findMany({
+        where: { teamId: project.teamId },
+        select: {
+          userId: true,
+          user: {
+            select: USER_SUMMARY_SELECT,
+          },
+        },
+      });
+
+      const mentionUserIds = this.resolveMentionUserIds(dto, teamMembers, currentUser.sub);
+
+      return await this.prisma.projectChatMessage.create({
+        data: {
+          projectId,
+          authorId: currentUser.sub,
+          content: dto.content.trim(),
+          mentions:
+            mentionUserIds.length > 0
+              ? {
+                  create: mentionUserIds.map((userId) => ({ userId })),
+                }
+              : undefined,
+        },
+        include: {
+          author: {
+            select: USER_SUMMARY_SELECT,
+          },
+          mentions: {
+            include: {
+              user: {
+                select: USER_SUMMARY_SELECT,
+              },
+            },
+          },
+        },
+      });
+    } catch (error) {
+      this.rethrowPrismaRuntimeError(error);
+    }
+  }
+
+  private rethrowPrismaRuntimeError(error: unknown): never {
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      // P2021/P2022 generally indicate the chat migration has not been applied in the running database.
+      if (error.code === "P2021" || error.code === "P2022") {
+        throw new ServiceUnavailableException(
+          "Project chat storage is not ready. Run Prisma migrations and restart the API.",
+        );
+      }
+    }
+
+    throw error;
+  }
+
+  private resolveMentionUserIds(
+    dto: CreateProjectChatMessageDto,
+    teamMembers: TeamMemberWithUser[],
+    currentUserId: string,
+  ): string[] {
+    const teamUserIds = new Set(teamMembers.map((member) => member.userId));
+    const explicitUserIds = (dto.mentionUserIds ?? []).filter((userId) => teamUserIds.has(userId));
+
+    const mentionsFromContent = this.findMentionedUsersByContent(dto.content, teamMembers);
+    const resolved = [...new Set([...explicitUserIds, ...mentionsFromContent])];
+
+    return resolved.filter((userId) => userId !== currentUserId);
+  }
+
+  private findMentionedUsersByContent(
+    content: string,
+    teamMembers: TeamMemberWithUser[],
+  ): string[] {
+    const tokens = this.extractMentionTokens(content);
+    if (tokens.length === 0) {
+      return [];
+    }
+
+    const mentionMap = new Map<string, string>();
+    for (const member of teamMembers) {
+      const handles = this.buildMentionHandles(member.user);
+      for (const handle of handles) {
+        mentionMap.set(handle, member.userId);
+      }
+    }
+
+    const matchedUserIds = new Set<string>();
+    for (const token of tokens) {
+      const userId = mentionMap.get(token);
+      if (userId) {
+        matchedUserIds.add(userId);
+      }
+    }
+
+    return Array.from(matchedUserIds);
+  }
+
+  private extractMentionTokens(content: string): string[] {
+    const matches = content.match(/(^|\s)@([a-zA-Z0-9_.-]{2,50})/g) ?? [];
+    return matches
+      .map((match) => match.trim().slice(1).toLowerCase())
+      .filter((value) => value.length > 1);
+  }
+
+  private buildMentionHandles(user: TeamMemberWithUser["user"]): string[] {
+    const handles = new Set<string>();
+
+    const emailHandle = user.email.split("@")[0]?.trim().toLowerCase();
+    if (emailHandle) {
+      handles.add(emailHandle);
+    }
+
+    const normalizedName = user.name?.trim().toLowerCase();
+    if (normalizedName) {
+      handles.add(normalizedName.replace(/\s+/g, ""));
+      handles.add(normalizedName.replace(/\s+/g, "."));
+      handles.add(normalizedName.replace(/\s+/g, "-"));
+
+      const firstName = normalizedName.split(/\s+/)[0];
+      if (firstName) {
+        handles.add(firstName);
+      }
+    }
+
+    return Array.from(handles);
+  }
+}

--- a/apps/web/actions/chat.actions.spec.ts
+++ b/apps/web/actions/chat.actions.spec.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const revalidatePath = vi.fn();
+const get = vi.fn();
+const post = vi.fn();
+
+vi.mock("next/cache", () => ({
+  revalidatePath,
+}));
+
+vi.mock("@/lib/api-client", () => ({
+  get,
+  post,
+}));
+
+describe("chat actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns validation error for invalid chat payload", async () => {
+    const { createProjectChatMessage } = await import("./chat.actions");
+    const result = await createProjectChatMessage("project_1", { content: "" });
+
+    expect(result.data).toBeNull();
+    expect(result.error).toBeTruthy();
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it("requests project chat messages", async () => {
+    get.mockResolvedValueOnce([]);
+    const { getProjectChatMessages } = await import("./chat.actions");
+
+    await getProjectChatMessages("project_1");
+
+    expect(get).toHaveBeenCalledWith("/projects/project_1/chat/messages");
+  });
+
+  it("revalidates teams path after creating a message", async () => {
+    post.mockResolvedValueOnce({
+      id: "msg_1",
+      content: "Hello",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      projectId: "project_1",
+      authorId: "user_1",
+      author: {
+        id: "user_1",
+        email: "owner@example.com",
+        name: "Owner",
+        avatarUrl: null,
+      },
+      mentions: [],
+    });
+    const { createProjectChatMessage } = await import("./chat.actions");
+
+    const result = await createProjectChatMessage("project_1", {
+      content: "Hello world",
+      mentionUserIds: ["user_2"],
+    });
+
+    expect(result.error).toBeNull();
+    expect(revalidatePath).toHaveBeenCalledWith("/teams");
+  });
+});

--- a/apps/web/actions/chat.actions.ts
+++ b/apps/web/actions/chat.actions.ts
@@ -1,0 +1,45 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import type { ActionResult, ProjectChatMessage } from "@repo/types";
+
+import { get, post } from "@/lib/api-client";
+
+import { fail, ok } from "./utils";
+
+const projectIdSchema = z.string().min(1);
+const createProjectChatMessageSchema = z.object({
+  content: z.string().min(1).max(2000),
+  mentionUserIds: z.array(z.string().min(1)).max(20).optional(),
+});
+
+export async function getProjectChatMessages(
+  projectId: string,
+): Promise<ActionResult<ProjectChatMessage[]>> {
+  try {
+    const parsedProjectId = projectIdSchema.parse(projectId);
+    const data = await get<ProjectChatMessage[]>(`/projects/${parsedProjectId}/chat/messages`);
+    return ok(data);
+  } catch (error) {
+    return fail(error);
+  }
+}
+
+export async function createProjectChatMessage(
+  projectId: string,
+  message: { content: string; mentionUserIds?: string[] },
+): Promise<ActionResult<ProjectChatMessage>> {
+  try {
+    const parsedProjectId = projectIdSchema.parse(projectId);
+    const parsedPayload = createProjectChatMessageSchema.parse(message);
+    const data = await post<ProjectChatMessage>(
+      `/projects/${parsedProjectId}/chat/messages`,
+      parsedPayload,
+    );
+    revalidatePath("/teams");
+    return ok(data);
+  } catch (error) {
+    return fail(error);
+  }
+}

--- a/apps/web/actions/utils.ts
+++ b/apps/web/actions/utils.ts
@@ -1,8 +1,36 @@
 import type { ActionResult } from "@repo/types";
 
+type ApiLikeError = {
+  message?: string | string[];
+};
+
+function extractStructuredError(raw: string): string | null {
+  const value = raw.trim();
+  if (!value.startsWith("{") && !value.startsWith("[")) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(value) as ApiLikeError;
+
+    if (Array.isArray(parsed.message)) {
+      return parsed.message.join(", ");
+    }
+
+    if (typeof parsed.message === "string" && parsed.message.trim().length > 0) {
+      return parsed.message;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 export function normalizeActionError(error: unknown): string {
   if (error instanceof Error) {
-    return error.message;
+    const structured = extractStructuredError(error.message);
+    return structured ?? error.message;
   }
 
   return "Unexpected error";

--- a/apps/web/app/(dashboard)/teams/[teamId]/projects/[projectId]/tasks/[taskId]/page.tsx
+++ b/apps/web/app/(dashboard)/teams/[teamId]/projects/[projectId]/tasks/[taskId]/page.tsx
@@ -1,17 +1,19 @@
 import Link from "next/link";
 import { ArrowLeft, CirclePlus, Paperclip } from "lucide-react";
-import type { TaskDetail, UserSummary } from "@repo/types";
+import type { ProjectChatMessage, TaskDetail, UserSummary } from "@repo/types";
 
+import { getProjectChatMessages } from "@/actions/chat.actions";
 import { getTask } from "@/actions/task.actions";
 import { getTeam } from "@/actions/team.actions";
 import { PageHeader } from "@/components/layout/page-header";
 import { TaskCommentBox } from "@/components/tasks/task-comment-box";
 import { TaskEditForm } from "@/components/tasks/task-edit-form";
+import { auth } from "@/lib/auth";
 import {
   taskPriorityLabel,
   taskPriorityTone,
   taskStatusLabel,
-  taskStatusTone
+  taskStatusTone,
 } from "@/components/tasks/task-meta";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
@@ -27,7 +29,11 @@ function formatDate(value: TaskDetail["dueDate"]): string {
     return "Not set";
   }
 
-  return new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", year: "numeric" }).format(parsed);
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(parsed);
 }
 
 function formatRelativeTime(value: TaskDetail["createdAt"]): string {
@@ -74,17 +80,23 @@ function isOverdue(value: TaskDetail["dueDate"]): boolean {
 
 export default async function TaskDetailPage({
   params,
-  searchParams
+  searchParams,
 }: {
   params: Promise<{ teamId: string; projectId: string; taskId: string }>;
   searchParams: Promise<{ mode?: string }>;
 }) {
   const { teamId, projectId, taskId } = await params;
   const { mode } = await searchParams;
-  const result = await getTask(projectId, taskId);
-  const teamResult = await getTeam(teamId);
+  const [result, teamResult, chatResult, session] = await Promise.all([
+    getTask(projectId, taskId),
+    getTeam(teamId),
+    getProjectChatMessages(projectId),
+    auth(),
+  ]);
   const task: TaskDetail | null = result.data;
   const assignees: UserSummary[] = (teamResult.data?.members ?? []).map((member) => member.user);
+  const chatMessages: ProjectChatMessage[] = chatResult.data ?? [];
+  const currentUserId = session?.user?.id ?? null;
   const taskPath = `/teams/${teamId}/projects/${projectId}/tasks/${taskId}`;
   const isEditing = mode === "edit";
 
@@ -97,7 +109,7 @@ export default async function TaskDetailPage({
   }
 
   return (
-    <main className="mx-auto grid w-full max-w-4xl gap-5">
+    <main className="mx-auto grid w-full max-w-6xl gap-5">
       <PageHeader
         eyebrow="Task"
         title={isEditing ? task.title : "Task Details"}
@@ -134,16 +146,70 @@ export default async function TaskDetailPage({
           <TaskEditForm projectId={projectId} task={task} assignees={assignees} />
         </Card>
       ) : (
-        <section className="grid items-start gap-5 lg:grid-cols-[minmax(0,1fr)_300px]">
-          <Card className="grid self-start gap-6 p-5">
+        <section className="grid items-start gap-5 xl:grid-cols-[minmax(0,1fr)_430px]">
+          <Card className="grid self-start gap-5 p-5">
             <div className="grid gap-1">
               <p className="text-2xl font-semibold tracking-tight text-foreground">{task.title}</p>
             </div>
 
             <div className="grid gap-1">
               <p className="whitespace-pre-wrap text-sm leading-6 text-foreground">
-                {task.description?.trim() ? task.description : "No task description has been added yet."}
+                {task.description?.trim()
+                  ? task.description
+                  : "No task description has been added yet."}
               </p>
+            </div>
+
+            <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
+              <div className="grid gap-1 rounded-lg border border-border/70 bg-popover/40 px-3 py-2">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                  Priority
+                </p>
+                <div className="min-h-7 flex items-center">
+                  <Badge className={`${taskPriorityTone(task.priority)} w-fit`}>
+                    {taskPriorityLabel(task.priority)}
+                  </Badge>
+                </div>
+              </div>
+
+              <div className="grid gap-1 rounded-lg border border-border/70 bg-popover/40 px-3 py-2">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                  Status
+                </p>
+                <div className="min-h-7 flex items-center">
+                  <Badge className={`${taskStatusTone(task.status)} w-fit`}>
+                    {taskStatusLabel(task.status)}
+                  </Badge>
+                </div>
+              </div>
+
+              <div className="grid gap-1 rounded-lg border border-border/70 bg-popover/40 px-3 py-2">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                  Due Date
+                </p>
+                <p
+                  className={`min-h-7 text-sm font-medium ${isOverdue(task.dueDate) ? "text-destructive" : "text-foreground"}`}
+                >
+                  {formatDate(task.dueDate)}
+                </p>
+              </div>
+
+              <div className="grid gap-1 rounded-lg border border-border/70 bg-popover/40 px-3 py-2">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                  Assignee
+                </p>
+                <div className="min-h-7 flex items-center gap-2">
+                  <UserAvatar
+                    name={task.assignee?.name}
+                    email={task.assignee?.email}
+                    avatarUrl={task.assignee?.avatarUrl}
+                    className="h-6 w-6 text-[10px]"
+                  />
+                  <span className="truncate text-sm font-medium text-foreground">
+                    {task.assignee?.name ?? task.assignee?.email ?? "Unassigned"}
+                  </span>
+                </div>
+              </div>
             </div>
 
             <div className="flex items-center justify-between gap-2 text-muted-foreground">
@@ -154,7 +220,10 @@ export default async function TaskDetailPage({
                 <CirclePlus className="h-4 w-4" />
                 Add sub-issues
               </button>
-              <button type="button" className="inline-flex items-center transition-colors hover:text-foreground">
+              <button
+                type="button"
+                className="inline-flex items-center transition-colors hover:text-foreground"
+              >
                 <Paperclip className="h-4 w-4" />
               </button>
             </div>
@@ -162,7 +231,10 @@ export default async function TaskDetailPage({
             <div className="grid gap-4 border-t border-border pt-5">
               <div className="flex items-center justify-between gap-2">
                 <h3 className="text-lg font-semibold text-foreground">Activity</h3>
-                <button type="button" className="text-sm text-muted-foreground transition-colors hover:text-foreground">
+                <button
+                  type="button"
+                  className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+                >
                   Unsubscribe
                 </button>
               </div>
@@ -175,34 +247,26 @@ export default async function TaskDetailPage({
                   className="h-7 w-7 text-xs"
                 />
                 <p>
-                  {(task.creator?.name ?? task.creator?.email ?? "A member")} created this task • {formatRelativeTime(task.createdAt)}
+                  {task.creator?.name ?? task.creator?.email ?? "A member"} created this task •{" "}
+                  {formatRelativeTime(task.createdAt)}
                 </p>
               </div>
-
-              <TaskCommentBox />
             </div>
           </Card>
 
-          <Card className="h-fit self-start p-5">
-            <div className="divide-y divide-border">
-              <div className="grid gap-1 py-3 first:pt-0">
-                <p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">Priority</p>
-                <Badge className={`${taskPriorityTone(task.priority)} w-fit`}>{taskPriorityLabel(task.priority)}</Badge>
+          <Card className="h-fit self-start p-4">
+            <div className="grid gap-3">
+              <div className="flex items-center justify-between gap-2 border-b border-border pb-2">
+                <h3 className="text-sm font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                  Chat
+                </h3>
               </div>
-              <div className="grid gap-1 py-3">
-                <p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">Status</p>
-                <Badge className={`${taskStatusTone(task.status)} w-fit`}>{taskStatusLabel(task.status)}</Badge>
-              </div>
-              <div className="grid gap-1 py-3">
-                <p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">Due Date</p>
-                <p className={`text-sm ${isOverdue(task.dueDate) ? "text-destructive" : "text-foreground"}`}>
-                  {formatDate(task.dueDate)}
-                </p>
-              </div>
-              <div className="grid gap-1 py-3 last:pb-0">
-                <p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">Assignee</p>
-                <p className="text-sm text-foreground">{task.assignee?.name ?? task.assignee?.email ?? "Unassigned"}</p>
-              </div>
+              <TaskCommentBox
+                projectId={projectId}
+                members={assignees}
+                initialMessages={chatMessages}
+                currentUserId={currentUserId}
+              />
             </div>
           </Card>
         </section>

--- a/apps/web/components/tasks/task-comment-box.tsx
+++ b/apps/web/components/tasks/task-comment-box.tsx
@@ -1,29 +1,414 @@
 "use client";
 
-import { Paperclip, SendHorizontal } from "lucide-react";
+import { useEffect, useMemo, useRef, useState, useTransition } from "react";
+import { ArrowUp, AtSign, Loader2, Paperclip } from "lucide-react";
+import type { ProjectChatMessage, UserSummary } from "@repo/types";
 
-import { Button } from "@/components/ui/button";
+import { createProjectChatMessage } from "@/actions/chat.actions";
 import { Textarea } from "@/components/ui/textarea";
+import { UserAvatar } from "@/components/ui/user-avatar";
 
-export function TaskCommentBox() {
+type MentionContext = {
+  start: number;
+  end: number;
+  query: string;
+};
+
+type MentionOption = {
+  userId: string;
+  name: string;
+  email: string;
+  avatarUrl?: string | null;
+  handle: string;
+  searchableHandles: string[];
+};
+
+function getEmailHandle(email?: string | null): string | null {
+  const value = email?.split("@")[0]?.trim().toLowerCase();
+  return value && value.length > 1 ? value : null;
+}
+
+function getNameHandle(name?: string | null): string | null {
+  const value = name?.trim().toLowerCase().replace(/\s+/g, ".");
+  return value && value.length > 1 ? value : null;
+}
+
+function buildMentionOption(user: UserSummary): MentionOption {
+  const emailHandle = getEmailHandle(user.email);
+  const nameHandle = getNameHandle(user.name);
+  const handle = emailHandle ?? nameHandle ?? `user.${user.id.slice(0, 6).toLowerCase()}`;
+
+  const searchableHandles = Array.from(
+    new Set(
+      [
+        handle,
+        emailHandle,
+        nameHandle,
+        user.name?.trim().toLowerCase().replace(/\s+/g, ""),
+        user.name?.trim().toLowerCase().split(/\s+/)[0],
+      ].filter((value): value is string => Boolean(value)),
+    ),
+  );
+
+  return {
+    userId: user.id,
+    name: user.name ?? user.email,
+    email: user.email,
+    avatarUrl: user.avatarUrl,
+    handle,
+    searchableHandles,
+  };
+}
+
+function extractMentionContext(content: string, cursor: number): MentionContext | null {
+  const before = content.slice(0, cursor);
+  const atIndex = before.lastIndexOf("@");
+
+  if (atIndex < 0) {
+    return null;
+  }
+
+  if (atIndex > 0 && !/\s/.test(before[atIndex - 1] ?? "")) {
+    return null;
+  }
+
+  const query = before.slice(atIndex + 1);
+  if (/[^a-zA-Z0-9_.-]/.test(query)) {
+    return null;
+  }
+
+  return {
+    start: atIndex,
+    end: cursor,
+    query: query.toLowerCase(),
+  };
+}
+
+function resolveMentionUserIds(content: string, mentionOptions: MentionOption[]): string[] {
+  const mentionMap = new Map<string, string>();
+  for (const option of mentionOptions) {
+    for (const handle of option.searchableHandles) {
+      mentionMap.set(handle, option.userId);
+    }
+  }
+
+  const matches = content.match(/(^|\s)@([a-zA-Z0-9_.-]{2,50})/g) ?? [];
+  const mentionedUserIds = new Set<string>();
+  for (const match of matches) {
+    const handle = match.trim().slice(1).toLowerCase();
+    const userId = mentionMap.get(handle);
+    if (userId) {
+      mentionedUserIds.add(userId);
+    }
+  }
+
+  return Array.from(mentionedUserIds);
+}
+
+function formatTime(value: ProjectChatMessage["createdAt"]): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "now";
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(date);
+}
+
+function resizeComposerTextarea(textarea: HTMLTextAreaElement | null): void {
+  if (!textarea) {
+    return;
+  }
+
+  textarea.style.height = "0px";
+  const nextHeight = Math.min(textarea.scrollHeight, 128);
+  textarea.style.height = `${Math.max(nextHeight, 40)}px`;
+}
+
+function buildHighlightedContent(
+  message: ProjectChatMessage,
+  isOwnMessage: boolean,
+): React.ReactNode {
+  const mentionHandles = new Set<string>();
+  for (const mention of message.mentions) {
+    const option = buildMentionOption(mention.user);
+    for (const handle of option.searchableHandles) {
+      mentionHandles.add(handle);
+    }
+  }
+
+  const tokens = message.content.split(/(@[a-zA-Z0-9_.-]{2,50})/g);
+  const mentionClassName = isOwnMessage
+    ? "font-semibold text-primary-foreground"
+    : "font-semibold text-primary";
+
+  return tokens.map((token, index) => {
+    if (token.startsWith("@")) {
+      const handle = token.slice(1).toLowerCase();
+      if (mentionHandles.has(handle)) {
+        return (
+          <span key={`${message.id}-token-${index}`} className={mentionClassName}>
+            {token}
+          </span>
+        );
+      }
+    }
+
+    return <span key={`${message.id}-token-${index}`}>{token}</span>;
+  });
+}
+
+export function TaskCommentBox({
+  projectId,
+  members,
+  initialMessages,
+  currentUserId,
+}: {
+  projectId: string;
+  members: UserSummary[];
+  initialMessages: ProjectChatMessage[];
+  currentUserId?: string | null;
+}) {
+  const [messages, setMessages] = useState<ProjectChatMessage[]>(initialMessages);
+  const [content, setContent] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const messagesRef = useRef<HTMLDivElement | null>(null);
+  const [mentionContext, setMentionContext] = useState<MentionContext | null>(null);
+
+  const mentionOptions = useMemo(
+    () => members.map((member) => buildMentionOption(member)),
+    [members],
+  );
+  const visibleMentionOptions = useMemo(() => {
+    if (!mentionContext) {
+      return [];
+    }
+
+    return mentionOptions
+      .filter((option) =>
+        mentionContext.query.length === 0
+          ? true
+          : option.searchableHandles.some((handle) => handle.startsWith(mentionContext.query)),
+      )
+      .slice(0, 6);
+  }, [mentionContext, mentionOptions]);
+
+  useEffect(() => {
+    const container = messagesRef.current;
+    if (!container) {
+      return;
+    }
+
+    container.scrollTop = container.scrollHeight;
+  }, [messages]);
+
+  useEffect(() => {
+    resizeComposerTextarea(textareaRef.current);
+  }, [content]);
+
+  function updateMentionContext(nextContent: string): void {
+    const cursor = textareaRef.current?.selectionStart ?? nextContent.length;
+    setMentionContext(extractMentionContext(nextContent, cursor));
+  }
+
+  function applyMention(option: MentionOption): void {
+    if (!mentionContext) {
+      return;
+    }
+
+    const nextContent = `${content.slice(0, mentionContext.start)}@${option.handle} ${content.slice(mentionContext.end)}`;
+    setContent(nextContent);
+    setMentionContext(null);
+
+    requestAnimationFrame(() => {
+      const textarea = textareaRef.current;
+      if (!textarea) {
+        return;
+      }
+
+      const nextCursor = mentionContext.start + option.handle.length + 2;
+      textarea.focus();
+      textarea.setSelectionRange(nextCursor, nextCursor);
+    });
+  }
+
+  function sendMessage(): void {
+    const trimmed = content.trim();
+    if (!trimmed || isPending) {
+      return;
+    }
+
+    const mentionUserIds = resolveMentionUserIds(trimmed, mentionOptions);
+    setError(null);
+
+    startTransition(async () => {
+      const result = await createProjectChatMessage(projectId, {
+        content: trimmed,
+        mentionUserIds,
+      });
+
+      if (result.error || !result.data) {
+        setError(result.error ?? "Unable to send comment.");
+        return;
+      }
+
+      setMessages((previous) => [...previous, result.data as ProjectChatMessage]);
+      setContent("");
+      setMentionContext(null);
+    });
+  }
+
   return (
-    <div className="rounded-lg border border-border bg-muted/20 p-3">
-      <Textarea
-        placeholder="Leave a comment..."
-        className="min-h-[110px] resize-none border-0 bg-transparent p-0 shadow-none focus-visible:ring-0"
-      />
-      <div className="mt-3 flex items-center justify-between gap-2">
-        <Button type="button" variant="ghost" className="h-8 w-8 p-0 text-muted-foreground">
-          <Paperclip className="h-4 w-4" />
-        </Button>
-        <button
-          type="button"
-          aria-label="Send comment"
-          className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border bg-popover text-foreground transition-colors hover:bg-accent"
-        >
-          <SendHorizontal className="h-4 w-4 translate-x-[0.5px]" />
-        </button>
+    <div className="relative grid gap-3 rounded-xl border border-border bg-card/70 p-3 sm:p-4">
+      <div ref={messagesRef} className="max-h-[400px] min-h-[220px] space-y-2 overflow-y-auto pr-1">
+        {messages.length === 0 ? (
+          <div className="grid h-full min-h-[200px] place-items-center rounded-lg border border-dashed border-border bg-popover/40 px-4">
+            <p className="text-center text-sm text-muted-foreground">
+              No comments yet. Start the conversation.
+            </p>
+          </div>
+        ) : (
+          messages.map((message) => {
+            const isOwnMessage = Boolean(currentUserId && message.authorId === currentUserId);
+
+            return (
+              <article
+                key={message.id}
+                className={`flex ${isOwnMessage ? "justify-end" : "justify-start"}`}
+              >
+                <div
+                  className={`flex max-w-[85%] flex-col gap-1 ${isOwnMessage ? "items-end" : "items-start"}`}
+                >
+                  <div
+                    className={`flex items-center gap-2 text-[11px] text-muted-foreground ${
+                      isOwnMessage ? "justify-end" : "justify-start"
+                    }`}
+                  >
+                    {!isOwnMessage ? (
+                      <UserAvatar
+                        name={message.author?.name}
+                        email={message.author?.email}
+                        avatarUrl={message.author?.avatarUrl}
+                        className="h-5 w-5 text-[10px]"
+                      />
+                    ) : null}
+                    <span className="max-w-[160px] truncate">
+                      {message.author?.name ?? message.author?.email ?? "Unknown user"}
+                    </span>
+                    <span>•</span>
+                    <span>{formatTime(message.createdAt)}</span>
+                  </div>
+
+                  <div
+                    className={`rounded-2xl px-3 py-2 text-sm leading-6 shadow-sm ${
+                      isOwnMessage
+                        ? "rounded-br-md bg-primary text-primary-foreground"
+                        : "rounded-bl-md border border-border bg-popover text-foreground"
+                    }`}
+                  >
+                    <p className="whitespace-pre-wrap break-words">
+                      {buildHighlightedContent(message, isOwnMessage)}
+                    </p>
+                  </div>
+                </div>
+              </article>
+            );
+          })
+        )}
       </div>
+
+      <div className="relative rounded-2xl border border-border bg-background/90 px-2 py-2 shadow-sm">
+        {mentionContext && visibleMentionOptions.length > 0 ? (
+          <div className="absolute inset-x-2 bottom-full z-20 mb-2 grid gap-1 rounded-lg border border-border bg-popover p-1 shadow-md">
+            {visibleMentionOptions.map((option) => (
+              <button
+                key={option.userId}
+                type="button"
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                  applyMention(option);
+                }}
+                className="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-foreground transition-colors hover:bg-accent"
+              >
+                <UserAvatar
+                  name={option.name}
+                  email={option.email}
+                  avatarUrl={option.avatarUrl}
+                  className="h-6 w-6 text-[10px]"
+                />
+                <span className="min-w-0 flex-1 truncate">{option.name}</span>
+                <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                  <AtSign className="h-3 w-3" />
+                  {option.handle}
+                </span>
+              </button>
+            ))}
+          </div>
+        ) : null}
+
+        <div className="flex items-end gap-2">
+          <button
+            type="button"
+            aria-label="Attach file"
+            disabled
+            className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-border bg-popover text-foreground/80 transition-colors hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-80"
+          >
+            <Paperclip className="h-4 w-4" strokeWidth={2.2} />
+          </button>
+
+          <Textarea
+            ref={textareaRef}
+            value={content}
+            onChange={(event) => {
+              const nextValue = event.target.value;
+              setContent(nextValue);
+              resizeComposerTextarea(event.currentTarget);
+              updateMentionContext(nextValue);
+            }}
+            onKeyUp={(event) => {
+              const target = event.currentTarget;
+              setMentionContext(
+                extractMentionContext(target.value, target.selectionStart ?? target.value.length),
+              );
+            }}
+            onClick={(event) => {
+              const target = event.currentTarget;
+              setMentionContext(
+                extractMentionContext(target.value, target.selectionStart ?? target.value.length),
+              );
+            }}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && !event.shiftKey) {
+                event.preventDefault();
+                sendMessage();
+              }
+            }}
+            maxLength={2000}
+            placeholder="Leave a comment..."
+            className="h-10 min-h-10 max-h-32 resize-none border-0 bg-transparent px-1 py-2.5 leading-5 shadow-none focus-visible:ring-0"
+          />
+
+          <button
+            type="button"
+            aria-label="Send comment"
+            disabled={isPending || content.trim().length === 0}
+            onClick={sendMessage}
+            className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-transparent bg-primary text-primary-foreground shadow-sm transition-all hover:brightness-95 active:scale-[0.98] disabled:cursor-not-allowed disabled:border-border disabled:bg-muted disabled:text-muted-foreground"
+          >
+            {isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" strokeWidth={2.3} />
+            ) : (
+              <ArrowUp className="h-4 w-4" strokeWidth={2.35} />
+            )}
+          </button>
+        </div>
+      </div>
+
+      {error ? <p className="text-xs text-destructive">{error}</p> : null}
     </div>
   );
 }

--- a/apps/web/components/ui/textarea.tsx
+++ b/apps/web/components/ui/textarea.tsx
@@ -1,18 +1,24 @@
 "use client";
 
-import type { TextareaHTMLAttributes } from "react";
+import { forwardRef, type TextareaHTMLAttributes } from "react";
 
 import { cn } from "@/lib/utils";
 
-export function Textarea({ className, ...props }: TextareaHTMLAttributes<HTMLTextAreaElement>) {
+export const Textarea = forwardRef<
+  HTMLTextAreaElement,
+  TextareaHTMLAttributes<HTMLTextAreaElement>
+>(({ className, ...props }, ref) => {
   return (
     <textarea
+      ref={ref}
       className={cn(
         "min-h-24 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground shadow-sm",
         "outline-none placeholder:text-muted-foreground focus:ring-2 focus:ring-ring",
-        className
+        className,
       )}
       {...props}
     />
   );
-}
+});
+
+Textarea.displayName = "Textarea";

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     }

--- a/packages/types/src/contracts.ts
+++ b/packages/types/src/contracts.ts
@@ -77,6 +77,23 @@ export interface TaskDetail extends TaskItem {
   creator?: UserSummary;
 }
 
+export interface ProjectChatMention {
+  id: string;
+  userId: string;
+  user: UserSummary;
+}
+
+export interface ProjectChatMessage {
+  id: string;
+  content: string;
+  createdAt: DateValue;
+  updatedAt: DateValue;
+  projectId: string;
+  authorId: string;
+  author: UserSummary;
+  mentions: ProjectChatMention[];
+}
+
 export interface DeleteResult {
   deleted: boolean;
 }


### PR DESCRIPTION
## Summary
This PR introduces project chat as part of the task detail experience, with end-to-end backend integration and UI updates.

## What’s Included
- Added backend project chat module in API:
  - `GET /projects/:projectId/chat/messages`
  - `POST /projects/:projectId/chat/messages`
- Added Prisma schema + migration for:
  - `ProjectChatMessage`
  - `ProjectChatMention`
- Added mention support (`@user`) with mention-user resolution and persistence.
- Integrated chat into task detail page (right-side chat pane).
- Removed chat from board page and kept chat focused on task detail.
- Upgraded task detail layout:
  - Better meta cards (`Priority`, `Status`, `Due Date`, `Assignee`)
  - Cleaner information hierarchy and spacing
- Improved chat composer UX:
  - WhatsApp-style bubble layout
  - Auto-resizing input
  - Better send button states/loading
  - Consistent icon sizing

## Reliability/Validation
- Added/updated tests for chat actions and service behavior.
- Added safer error normalization on web action layer.
- Added Prisma runtime handling for missing chat-table migration cases.
- Verified:
  - `pnpm lint`
  - `pnpm test`
  - `pnpm build`

## Migration Note
Run DB migration before testing chat in environments using this branch:
- `pnpm --filter api prisma migrate deploy`
- `pnpm --filter api prisma generate`

## Impact
- No breaking API changes to existing endpoints.
- New DB objects are introduced for chat support.
